### PR TITLE
docs: declutter README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,4 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/hutaobo/pyXenium/main/docs/_static/branding/pyxenium-horizontal-dark.png" alt="pyXenium horizontal logo" width="960">
-</p>
-
 <h1 align="center">pyXenium</h1>
-
-<p align="center">
-  Load, analyze, and interpret 10x Genomics Xenium spatial data in one Python toolkit.
-</p>
 
 <p align="center">
   <a href="https://pypi.org/project/pyXenium/"><img src="https://img.shields.io/pypi/v/pyXenium.svg" alt="PyPI version"></a>
@@ -15,20 +7,6 @@
   <a href="https://github.com/hutaobo/pyXenium/actions/workflows/ci.yml"><img src="https://github.com/hutaobo/pyXenium/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://pypi.org/project/pyXenium/"><img src="https://img.shields.io/pypi/pyversions/pyXenium.svg" alt="Python versions"></a>
   <a href="https://github.com/hutaobo/pyXenium/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-0a7f5a.svg" alt="License"></a>
-</p>
-
-<p align="center">
-  <a href="https://pypi.org/project/pyXenium/">PyPI</a>
-  ·
-  <a href="https://anaconda.org/conda-forge/pyxenium">conda-forge</a>
-  ·
-  <a href="https://pyxenium.readthedocs.io/en/latest/">Read the Docs</a>
-  ·
-  <a href="https://github.com/hutaobo/pyXenium">GitHub</a>
-  ·
-  <a href="https://pyxenium.readthedocs.io/en/latest/changelog.html">Changelog</a>
-  ·
-  <a href="https://github.com/hutaobo/pyXenium/releases">Releases</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Removes three header blocks for a cleaner top of the README: the logo banner, the one-line tagline, and the navigation link row (PyPI · conda-forge · …). The centered title, badge row, overview figure, and section table remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 由 Sourcery 提供的摘要

在保留项目核心介绍的前提下，精简 README 和文档总览图。

文档：
- 通过移除 README 头部的 logo 横幅、标语以及导航链接行，简化布局以获得更简洁的外观。
- 将 README 和文档中用于展示九大功能的总览图从 PNG 切换为共用的 SVG 资源，并相应调整周围的介绍文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Streamline the README and documentation overview figure while keeping the core project introduction intact.

Documentation:
- Simplify the README header by removing the logo banner, tagline, and navigation link row for a cleaner layout.
- Switch the nine-feature overview figure in the README and docs from PNG to a shared SVG asset and adjust surrounding intro text accordingly.

</details>