### PR TITLE
fix: green CI and align README Python version to 3.11+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.egg-info/
 .pytest_cache/
 .codex_deps/
+.claude/
 tmp_*.log
 build/
 dist/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <a href="https://anaconda.org/conda-forge/pyxenium"><img src="https://img.shields.io/conda/vn/conda-forge/pyxenium.svg" alt="Conda version"></a>
   <a href="https://pyxenium.readthedocs.io/en/latest/"><img src="https://readthedocs.org/projects/pyxenium/badge/?version=latest" alt="Read the Docs"></a>
   <a href="https://github.com/hutaobo/pyXenium/actions/workflows/ci.yml"><img src="https://github.com/hutaobo/pyXenium/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
-  <a href="https://pypi.org/project/pyXenium/"><img src="https://img.shields.io/pypi/pyversions/pyXenium.svg" alt="Python versions"></a>
+  <a href="https://pypi.org/project/pyXenium/"><img src="https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue.svg" alt="Python versions"></a>
   <a href="https://github.com/hutaobo/pyXenium/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-0a7f5a.svg" alt="License"></a>
 </p>
 
@@ -39,7 +39,7 @@ and run separately; pyXenium does not vendor them or add them as core runtime de
 - Conda package: [conda-forge](https://anaconda.org/conda-forge/pyxenium)
 - Documentation site: [pyxenium.readthedocs.io](https://pyxenium.readthedocs.io/en/latest/)
 - Canonical build status: [GitHub Actions CI](https://github.com/hutaobo/pyXenium/actions/workflows/ci.yml)
-- Supported Python: `>=3.8`
+- Supported Python: `>=3.11`
 - License: [GNU AGPL v3.0 only](https://github.com/hutaobo/pyXenium/blob/main/LICENSE)
 - Maintained by: `SPATHO AB`
 
@@ -69,7 +69,7 @@ For documentation work:
 pip install -e ".[docs]"
 ```
 
-For the optional SpatialPerturb Bridge runtime on Python 3.9+:
+For the optional SpatialPerturb Bridge runtime on Python 3.11+:
 
 ```bash
 pip install -e ".[perturb]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ pyxenium = "pyXenium.__main__:main"
 
 [project.optional-dependencies]
 perturb = [
-  "SpatialPerturb>=0.3; python_version >= '3.9'",
+  "SpatialPerturb>=0.3; python_version >= '3.11'",
 ]
 
 lazyslide = [

--- a/tests/test_gmi_module.py
+++ b/tests/test_gmi_module.py
@@ -211,7 +211,7 @@ def test_gmi_docs_and_package_data_are_canonical():
     api_gmi = (repo_root / "docs" / "api" / "gmi.md").read_text(encoding="utf-8")
     pyproject = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert "nine feature areas" in readme
+    assert "nine major sections" in readme
     assert "gmi" in api_index
     assert "pyXenium.gmi" in api_gmi
     assert "_vendor/Gmi/R/*" in pyproject


### PR DESCRIPTION
## CI fix
The README header trim (#6) replaced the literal phrase `nine feature areas` with `nine major sections`, but `tests/test_gmi_module.py::test_gmi_docs_and_package_data_are_canonical` pins that phrase — the sole pytest failure on 3.11/3.12/3.13. Updates the assertion to match the current wording (verified locally against the real files).

## Python 3.11+ alignment
`requires-python` and the CI matrix were already 3.11+; this aligns the docs/metadata:
- README: `Supported Python: >=3.11`, SpatialPerturb extra on `Python 3.11+`, and a static `3.11 | 3.12 | 3.13` Python badge. (The dynamic PyPI `pyversions` badge showed 3.8–3.13 because it reflects the *published* 0.4.6 metadata; it would only refresh on the next release.)
- `pyproject.toml`: perturb extra marker bumped to `python_version >= '3.11'`.

## Housekeeping
- `.gitignore`: ignore local `.claude/` agent tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

使文档和测试中声明的 Python 支持版本与现有的 3.11+ 要求保持一致，并修复由于 README 描述变更而导致的 CI 回归问题。

Bug Fixes（错误修复）:
- 更新 canonical-docs 测试以匹配当前 README 的表述，从而保证在 Python 3.11+ 上 CI 能通过。

Enhancements（功能改进）:
- 在 README 中将 Python 支持版本记录为 3.11+，并改为使用静态的 3.11–3.13 徽章。
- 收紧 SpatialPerturb 可选依赖，使其仅在 Python 3.11+ 环境中安装。

Chores（日常维护）:
- 在版本控制中忽略本地 `.claude/` 工具产物。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align documented and tested Python support with the existing 3.11+ requirement and fix the CI regression caused by a README wording change.

Bug Fixes:
- Update canonical-docs test to match the current README wording so CI passes on Python 3.11+.

Enhancements:
- Document Python support as 3.11+ in the README and switch to a static 3.11–3.13 badge.
- Tighten the SpatialPerturb optional dependency to only install on Python 3.11+.

Chores:
- Ignore local `.claude/` tooling artifacts in version control.

</details>